### PR TITLE
Cartesian Grids

### DIFF
--- a/src/GeophysicalModelGenerator.jl
+++ b/src/GeophysicalModelGenerator.jl
@@ -17,6 +17,10 @@ export
 
 export ReadCSV_LatLon, meshgrid, voxGrav
 
+abstract type AbstractGeneralGrid end                                    # general grid types 
+
+export AbstractGeneralGrid
+
 # julia standard library packages
 using DelimitedFiles, Statistics            
 
@@ -36,7 +40,7 @@ include("Paraview_output.jl")
 include("transformation.jl")
 include("voxel_gravity.jl")
 include("LaMEM_io.jl")
-include("LaMEM_geometry.jl")
+include("Setup_geometry.jl")
 include("stl.jl")
 
 # Add optional routines (only activated when the packages are loaded)

--- a/src/LaMEM_io.jl
+++ b/src/LaMEM_io.jl
@@ -14,7 +14,7 @@ export GetProcessorPartitioning, ReadData_VTR, ReadData_PVTR, CreatePartitioning
 """
 Structure that holds information about the LaMEM grid (usually read from an input file).
 """
-struct LaMEM_grid
+struct LaMEM_grid <: AbstractGeneralGrid
     nmark_x :: Int64
     nmark_y :: Int64
     nmark_z :: Int64
@@ -813,4 +813,14 @@ function CreatePartitioningFile(LaMEM_input::String,NumProc::Int64; LaMEM_dir::S
 
     return PartFile[1]
 
+end
+
+"""
+    X,Y,Z = coordinate_grids(Data::LaMEM_grid)
+
+Returns 3D coordinate arrays
+"""
+function coordinate_grids(Data::LaMEM_grid)
+
+    return Data.X, Data.Y, Data.Z
 end

--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -986,14 +986,17 @@ function CreateCartGrid(;
 
     FT = typeof(x[1])
     if      dim==1
+        x = FT.(x)
         L = (x[2] - x[1],)
         X₁= (x[1], )
     elseif  dim==2
+        x,z = FT.(x), FT.(z)
         L = (x[2] - x[1], z[2] - z[1])
         X₁= (x[1], z[1])
     else
-        L = (x[2] - x[1], z[2] - z[1], y[2] - y[1])
-        X₁= (x[1], z[1], y[1])
+        x,y,z = FT.(x), FT.(y), FT.(z)
+        L = (x[2] - x[1], y[2] - y[1], z[2] - z[1])
+        X₁= (x[1], y[1], z[1])
     end
     Xₙ  = X₁ .+ L  
     Δ   = L ./ (N .- 1)       

--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -703,12 +703,17 @@ CartData
 CartData(xyz::Tuple) = CartData(xyz[1],xyz[2],xyz[3],(Z=xyz[3],))
 
 """
-    Data = CartData(Grid::CartGrid, fields::NamedTuple) 
+    Data = CartData(Grid::CartGrid, fields::NamedTuple; y_val=0.0) 
 
 Returns a CartData set given a cartesian grid `Grid` and `fields` defined on that grid.
 """
-function CartData(Grid::CartGrid, fields::NamedTuple)
-    X,Y,Z = XYZGrid(Grid.coord1D[1], Grid.coord1D[2], Grid.coord1D[3])
+function CartData(Grid::CartGrid, fields::NamedTuple; y_val=0.0)
+    if length(Grid2D.N)==3
+        X,Y,Z = XYZGrid(Grid.coord1D[1], Grid.coord1D[2], Grid.coord1D[3])  # 3D grid
+
+    elseif length(Grid2D.N)==2
+        X,Y,Z = XYZGrid(Grid.coord1D[1], y_val, Grid.coord1D[2])  # 3D grid
+    end
     
     return CartData(X,Y,Z, fields)
 end

--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -702,21 +702,7 @@ CartData
 """
 CartData(xyz::Tuple) = CartData(xyz[1],xyz[2],xyz[3],(Z=xyz[3],))
 
-"""
-    Data = CartData(Grid::CartGrid, fields::NamedTuple; y_val=0.0) 
 
-Returns a CartData set given a cartesian grid `Grid` and `fields` defined on that grid.
-"""
-function CartData(Grid::CartGrid, fields::NamedTuple; y_val=0.0)
-    if length(Grid2D.N)==3
-        X,Y,Z = XYZGrid(Grid.coord1D[1], Grid.coord1D[2], Grid.coord1D[3])  # 3D grid
-
-    elseif length(Grid2D.N)==2
-        X,Y,Z = XYZGrid(Grid.coord1D[1], y_val, Grid.coord1D[2])  # 3D grid
-    end
-    
-    return CartData(X,Y,Z, fields)
-end
 
 """
     Convert2UTMzone(d::CartData, proj::ProjectionPoint)  
@@ -1069,4 +1055,27 @@ function coordinate_grids(Data::CartGrid)
     X,Y,Z = XYZGrid(NumValue(Data.coord1D[1]), NumValue(Data.coord1D[2]), NumValue(Data.coord1D[3]))
 
     return X,Y,Z
+end
+
+"""
+    Data = CartData(Grid::CartGrid, fields::NamedTuple; y_val=0.0) 
+
+Returns a CartData set given a cartesian grid `Grid` and `fields` defined on that grid.
+"""
+function CartData(Grid::CartGrid, fields::NamedTuple; y_val=0.0)
+    if length(Grid.N)==3
+        X,Y,Z = XYZGrid(Grid.coord1D[1], Grid.coord1D[2], Grid.coord1D[3])  # 3D grid
+    elseif length(Grid.N)==2
+        X,Y,Z = XYZGrid(Grid.coord1D[1], y_val, Grid.coord1D[2])  # 2D grid
+
+        # the fields need to be reshaped from 2D to 3D arrays; we replace them in the NamedTuple as follows
+        names = keys(fields)
+        for ifield = 1:length(names)
+            dat = reshape(fields[ifield],Grid.N[1],1,Grid.N[2]);    # reshape into 3D form
+            fields = merge(fields, [names[ifield] => dat])
+        end
+        
+    end
+    
+    return CartData(X,Y,Z, fields)
 end

--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -702,7 +702,16 @@ CartData
 """
 CartData(xyz::Tuple) = CartData(xyz[1],xyz[2],xyz[3],(Z=xyz[3],))
 
+"""
+    Data = CartData(Grid::CartGrid, fields::NamedTuple) 
 
+Returns a CartData set given a cartesian grid `Grid` and `fields` defined on that grid.
+"""
+function CartData(Grid::CartGrid, fields::NamedTuple)
+    X,Y,Z = XYZGrid(Grid.coord1D[1], Grid.coord1D[2], Grid.coord1D[3])
+    
+    return CartData(X,Y,Z, fields)
+end
 
 """
     Convert2UTMzone(d::CartData, proj::ProjectionPoint)  

--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -5,7 +5,8 @@ import Base: show
 
 export  GeoData, ParaviewData, UTMData, CartData,
         LonLatDepthGrid, XYZGrid, Velocity_SphericalToCartesian!,
-        Convert2UTMzone, Convert2CartData, ProjectionPoint
+        Convert2UTMzone, Convert2CartData, ProjectionPoint,
+        coordinate_grids
 
 """
     struct ProjectionPoint
@@ -142,7 +143,7 @@ GeoData
   attributes: ["note"]
 ```
 """
-struct GeoData
+struct GeoData <: AbstractGeneralGrid
     lon     ::  GeoUnit
     lat     ::  GeoUnit 
     depth   ::  GeoUnit
@@ -241,7 +242,7 @@ julia> Data_set    =   GeophysicalModelGenerator.GeoData(1.0:10.0,11.0:20.0,(-20
 julia> Data_cart = convert(ParaviewData, Data_set)
 ```
 """
-mutable struct ParaviewData
+mutable struct ParaviewData <: AbstractGeneralGrid
     x       ::  GeoUnit
     y       ::  GeoUnit
     z       ::  GeoUnit
@@ -353,7 +354,7 @@ julia> Write_Paraview(Data_set1, "Data_set1")
  "Data_set1.vts"
 ```
 """
-struct UTMData
+struct UTMData <: AbstractGeneralGrid
     EW       ::  GeoUnit
     NS       ::  GeoUnit 
     depth    ::  GeoUnit
@@ -605,7 +606,7 @@ GeoData
 which would allow visualizing this in paraview in the usual manner:
 
 """
-struct CartData
+struct CartData <: AbstractGeneralGrid
     x       ::  GeoUnit
     y       ::  GeoUnit 
     z       ::  GeoUnit
@@ -876,4 +877,45 @@ function Convert!(d,u)
     d = GeoUnit(d)             # convert to GeoUnit structure with units of u
 
     return d
+end
+
+"""
+    X,Y,Z = coordinate_grids(Data::CartData)
+
+Returns 3D coordinate arrays
+"""
+function coordinate_grids(Data::CartData)
+
+    return NumValue(Data.x), NumValue(Data.y), NumValue(Data.z)
+end
+
+"""
+    LON,LAT,Z = coordinate_grids(Data::GeoData)
+
+Returns 3D coordinate arrays
+"""
+function coordinate_grids(Data::GeoData)
+
+    return NumValue(Data.lon), NumValue(Data.lat), NumValue(Data.depth)
+end
+
+"""
+    EW,NS,Z = coordinate_grids(Data::UTMData)
+
+Returns 3D coordinate arrays
+"""
+function coordinate_grids(Data::UTMData)
+
+    return NumValue(Data.EW), NumValue(Data.NS), NumValue(Data.depth)
+end
+
+"""
+    X,Y,Z = coordinate_grids(Data::ParaviewData)
+
+Returns 3D coordinate arrays
+"""
+function coordinate_grids(Data::ParaviewData)
+    X,Y,Z = XYZGrid(NumValue(Data.x), NumValue(Data.y), NumValue(Data.z))
+
+    return X,Y,Z
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -788,6 +788,30 @@ function AboveSurface(Data_Cart::CartData, DataSurface_Cart::CartData; above=tru
 end
 
 """
+    Above = AboveSurface(Grid::CartGrid, DataSurface_Cart::CartData; above=true)
+
+Determines if points described by the `Grid` CartGrid structure are above the Cartesian surface `DataSurface_Cart`
+"""
+function AboveSurface(Grid::CartGrid, DataSurface_Cart::CartData; above=true)
+
+    X,Y,Z = XYZGrid(Grid.coord1D...)
+    Data = CartData(Grid,(Z=Z,))
+
+    return AboveSurface(Data, DataSurface_Cart; above=above)
+end
+
+
+"""
+    Below = BelowSurface(Grid::CartGrid, DataSurface_Cart::CartData)
+
+    Determines if points described by the `Grid` CartGrid structure are above the Cartesian surface `DataSurface_Cart`
+"""
+function BelowSurface(Grid::CartGrid, DataSurface_Cart::CartData)
+    return AboveSurface(Grid, DataSurface_Cart; above=false)
+end
+
+
+"""
     Below = BelowSurface(Data_Cart::ParaviewData, DataSurface_Cart::ParaviewData)
 
 Determines if points within the 3D Data_Cart structure are below the Cartesian surface DataSurface_Cart

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,10 @@ end
     include("test_lamem.jl")
 end
 
+@testset "SetupGeometry" begin
+    include("test_setup_geometry.jl")
+end
+
 @testset "STL" begin
     include("test_stl.jl")
 end

--- a/test/test_lamem.jl
+++ b/test/test_lamem.jl
@@ -1,4 +1,4 @@
-# test LaMEM i/o routines
+# test LaMEM I/O routines
 using Test, GeophysicalModelGenerator
 
 # Load LaMEM input file:

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -41,3 +41,6 @@ AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(4,8), phase=ConstantPhase(3), DipAng
 Data = CartData(Grid, (T=Temp, Phases=Phases))
 
 @test NumValue(Data.x[3,3,2]) ≈ 2.2222222222222223
+
+# To be tested: doing the same for cross-sections or horizontal slices
+Grid2D              =   CreateCartGrid(size=(10,30),x=(0.,10), z=(2.,10))

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -13,7 +13,7 @@ AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), Di
 @test sum(Temp) ≈ 1.4254722397218528e6
 
 AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
-@test sum(Temp) ≈ 1.4037222397218528e6
+@test sum(Temp) ≈ 1.4037222397218528e6 rtol=1e-6
 
 # CartData 
 X,Y,Z               =   XYZGrid(1.0:1:10.0, 11.0:1:20.0, -20:1:-10);
@@ -23,10 +23,10 @@ Phases              =   zeros(Int32,   size(Data));
 Grid                =   CartData(X,Y,Z,(DataFieldName=Data,))   
 
 AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
-@test sum(Temp) ≈ 1.4254722397218528e6
+@test sum(Temp) ≈ 1.4254722397218528e6  rtol=1e-6
 
 AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
-@test sum(Temp) ≈ 1.4037222397218528e6
+@test sum(Temp) ≈ 1.4037222397218528e6  rtol=1e-6
 
 # CartGrid
 Grid                =   CreateCartGrid(size=(10,20,30),x=(0.,10), y=(0.,10), z=(2.,10))
@@ -50,3 +50,17 @@ Phases2D            =   zeros(Int32,  Grid2D.N...);
 Data2D = CartData(Grid2D, (T=Temp2D, Phases=Phases2D))
 
 @test NumValue(Data.x[3,1,2]) ≈ 2.2222222222222223
+
+
+# test AboveSurface with the Grid object
+Grid        =   CreateCartGrid(size=(10,20,30),x=(0.,10), y=(0.,10), z=(-10.,2.))
+Temp        =   ones(Float64, Grid.N...)*1350;
+Phases      =   zeros(Int32,  Grid.N...);
+
+
+Topo_cart   =   CartData(XYZGrid(-1:.2:20,-12:.2:13,0));
+ind         =   AboveSurface(Grid, Topo_cart);
+@test sum(ind[1,1,:]) == 5
+
+ind         =   BelowSurface(Grid, Topo_cart);
+@test sum(ind[1,1,:]) == 25

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -36,3 +36,8 @@ Phases              =   zeros(Int32,  Grid.N...);
 AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(4,8), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
 
 @test maximum(Phases) == 3
+
+# Create a CartData structure from it
+Data = CartData(Grid, (T=Temp, Phases=Phases))
+
+@test NumValue(Data.x[3,3,2]) ≈ 2.2222222222222223

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -1,0 +1,30 @@
+# test setting geometries in the different grid types
+using Test, GeophysicalModelGenerator
+
+
+# GeoData
+Lon3D,Lat3D,Depth3D =   LonLatDepthGrid(1.0:1:10.0, 11.0:1:20.0, (-20:1:-10)*km);
+Data                =   zeros(size(Lon3D));
+Temp                =   ones(Float64, size(Data))*1350;
+Phases              =   zeros(Int32,   size(Data));
+Grid                =   GeoData(Lon3D,Lat3D,Depth3D,(DataFieldName=Data,))   
+
+AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
+@test sum(Temp) == 1.4254722397218528e6
+
+AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
+@test sum(Temp) == 1.4037222397218528e6
+
+# CartData 
+X,Y,Z               =   XYZGrid(1.0:1:10.0, 11.0:1:20.0, -20:1:-10);
+Data                =   zeros(size(X));
+Temp                =   ones(Float64, size(Data))*1350;
+Phases              =   zeros(Int32,   size(Data));
+Grid                =   CartData(X,Y,Z,(DataFieldName=Data,))   
+
+AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
+@test sum(Temp) == 1.4254722397218528e6
+
+AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
+@test sum(Temp) == 1.4037222397218528e6
+

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -10,10 +10,10 @@ Phases              =   zeros(Int32,   size(Data));
 Grid                =   GeoData(Lon3D,Lat3D,Depth3D,(DataFieldName=Data,))   
 
 AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
-@test sum(Temp) ≈ 1.4254722397218528e6
+@test sum(Temp[1,1,:]) ≈ 14850.0
 
 AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
-@test sum(Temp) ≈ 1.4037222397218528e6 rtol=1e-6
+@test sum(Temp[1,1,:]) ≈ 14850.0
 
 # CartData 
 X,Y,Z               =   XYZGrid(1.0:1:10.0, 11.0:1:20.0, -20:1:-10);
@@ -23,10 +23,10 @@ Phases              =   zeros(Int32,   size(Data));
 Grid                =   CartData(X,Y,Z,(DataFieldName=Data,))   
 
 AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
-@test sum(Temp) ≈ 1.4254722397218528e6  rtol=1e-6
+@test sum(Temp[1,1,:]) ≈ 14850.0
 
 AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
-@test sum(Temp) ≈ 1.4037222397218528e6  rtol=1e-6
+@test sum(Temp[1,1,:]) ≈ 14850.0
 
 # CartGrid
 Grid                =   CreateCartGrid(size=(10,20,30),x=(0.,10), y=(0.,10), z=(2.,10))

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -10,10 +10,10 @@ Phases              =   zeros(Int32,   size(Data));
 Grid                =   GeoData(Lon3D,Lat3D,Depth3D,(DataFieldName=Data,))   
 
 AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
-@test sum(Temp) == 1.4254722397218528e6
+@test sum(Temp) ≈ 1.4254722397218528e6
 
 AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
-@test sum(Temp) == 1.4037222397218528e6
+@test sum(Temp) ≈ 1.4037222397218528e6
 
 # CartData 
 X,Y,Z               =   XYZGrid(1.0:1:10.0, 11.0:1:20.0, -20:1:-10);
@@ -23,8 +23,16 @@ Phases              =   zeros(Int32,   size(Data));
 Grid                =   CartData(X,Y,Z,(DataFieldName=Data,))   
 
 AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
-@test sum(Temp) == 1.4254722397218528e6
+@test sum(Temp) ≈ 1.4254722397218528e6
 
 AddEllipsoid!(Phases,Temp,Grid, cen=(4,15,-17), axes=(1,2,3), StrikeAngle=90, DipAngle=45, phase=ConstantPhase(2), T=ConstantTemp(600))
-@test sum(Temp) == 1.4037222397218528e6
+@test sum(Temp) ≈ 1.4037222397218528e6
 
+# CartGrid
+Grid                =   CreateCartGrid(size=(10,20,30),x=(0.,10), y=(0.,10), z=(2.,10))
+Temp                =   ones(Float64, Grid.N...)*1350;
+Phases              =   zeros(Int32,  Grid.N...);
+
+AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(4,8), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
+
+@test maximum(Phases) == 3

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -42,5 +42,11 @@ Data = CartData(Grid, (T=Temp, Phases=Phases))
 
 @test NumValue(Data.x[3,3,2]) ≈ 2.2222222222222223
 
-# To be tested: doing the same for cross-sections or horizontal slices
+# Doing the same for vertical cross-sections
 Grid2D              =   CreateCartGrid(size=(10,30),x=(0.,10), z=(2.,10))
+Temp2D              =   ones(Float64, Grid2D.N...)*1350;
+Phases2D            =   zeros(Int32,  Grid2D.N...);
+
+Data2D = CartData(Grid2D, (T=Temp2D, Phases=Phases2D))
+
+@test NumValue(Data.x[3,1,2]) ≈ 2.2222222222222223


### PR DESCRIPTION
This introduces the `CartGrid` struct; an orthogonal Cartesian grid object which can be used in numerical codes and contains 1D vectors that give the coordinates in the 1D/2D/3D directions. 

You can generate a grid with:
```julia
julia> Grid      =   CreateCartGrid(size=(10,20,30),x=(0.,10), y=(0.,10), z=(2.,10))
julia> Temp    =   ones(Float64, Grid.N...)*1350;
julia> Phases =   zeros(Int32,  Grid.N...);
```

This allows you to set properties in the usual manner:
```julia
julia> AddBox!(Phases,Temp,Grid, xlim=(2,4), zlim=(-15,-10), phase=ConstantPhase(3), DipAngle=10, T=LinearTemp(Tbot=1350, Ttop=200))
```

Once this is generated, you can create a `CartData` structure from it with
```julia
julia> Data = CartData(Grid, (T=Temp, Phases=Phases))
```
Or, ofcourse, use `Temp`,`Phases` in different codes.
