### PR TITLE
Upgrade GMT dependency

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -16,6 +16,7 @@ jobs:
         version:
           - '1.7'
           - '1.8'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -14,10 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
           - '1.8'
           - '1.9'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
[GMT.jl](https://github.com/GenericMappingTools/GMT.jl) now has version 1.0 which uses `GMT_jll` (=precompiled binaries) by default. That makes it easier to use and as such we can add it as a direct dependency rather than as an optional one.

Yet, the issue is that it no longer works with Julia 1.7, but requires 1.8 & 1.9. Nightly is currently broken as well, but that is perhaps fixed before 1.10 is released. 
See the [discussion](https://github.com/GenericMappingTools/GMT.jl/issues/447) about `GMT_jll`.
Shall we increase the minimum required Julia version to >1.7 for `GMG` (and remove nightly from testing)?