### PR TITLE
Update utils.jl

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -850,9 +850,9 @@ function InterpolateDataFields2D(V::GeoData, Lon, Lat)
 
             for j=1:length(data_tuple)
                 if length(size(data_tuple[j]))==3
-                    interpol    =   linear_interpolation((Lon_vec, Lat_vec), ustrip.(data_tuple[j][:,:,1]),extrapolation_bc = NaN);      # create interpolation object
+                    interpol    =   linear_interpolation((Lon_vec, Lat_vec), ustrip.(data_tuple[j][:,:,1]),extrapolation_bc = Flat());      # create interpolation object
                 else
-                    interpol    =   linear_interpolation((Lon_vec, Lat_vec), ustrip.(data_tuple[j]),extrapolation_bc = NaN);      # create interpolation object
+                    interpol    =   linear_interpolation((Lon_vec, Lat_vec), ustrip.(data_tuple[j]),extrapolation_bc = Flat());      # create interpolation object
                 end
                 data_array[:,:,1,j] =   interpol.(Lon, Lat);          
             end
@@ -864,9 +864,9 @@ function InterpolateDataFields2D(V::GeoData, Lon, Lat)
         else
             # scalar field
             if length(size(V.fields[i]))==3
-                interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.fields[i][:,:,1], extrapolation_bc = NaN);            # create interpolation object
+                interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.fields[i][:,:,1], extrapolation_bc = Flat());            # create interpolation object
             else
-                interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.fields[i], extrapolation_bc = NaN);            # create interpolation object
+                interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.fields[i], extrapolation_bc = Flat());            # create interpolation object
             end
 
             data_new    =   interpol.(Lon, Lat);                                                 # interpolate data field
@@ -880,9 +880,9 @@ function InterpolateDataFields2D(V::GeoData, Lon, Lat)
 
     # Interpolate z-coordinate as well
     if length(size(V.lon))==3
-        interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.depth.val[:,:,1], extrapolation_bc = NaN);            # create interpolation object
+        interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.depth.val[:,:,1], extrapolation_bc = Flat());            # create interpolation object
     else
-        interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.depth.val, extrapolation_bc = NaN);            # create interpolation object
+        interpol    =   linear_interpolation((Lon_vec, Lat_vec), V.depth.val, extrapolation_bc = Flat());            # create interpolation object
     end
     depth_new =  interpol.(Lon, Lat);    
     
@@ -913,7 +913,7 @@ function InterpolateDataFields2D(V::UTMData, EW, NS)
             unit_array = zeros(size(data_array));
 
             for j=1:length(data_tuple)
-                interpol    =   linear_interpolation((EW_vec, NS_vec), ustrip.(data_tuple[j]),extrapolation_bc = NaN);      # create interpolation object
+                interpol    =   linear_interpolation((EW_vec, NS_vec), ustrip.(data_tuple[j]),extrapolation_bc = Flat());      # create interpolation object
                 data_array[:,:,1,j] =   interpol.(EW, NS);          
             end
             data_new    = tuple([data_array[:,:,1,c] for c in 1:size(data_array,4)]...)     # transform 3D matrix to tuple
@@ -921,9 +921,9 @@ function InterpolateDataFields2D(V::UTMData, EW, NS)
         else
             # scalar field
             if length(size(V.fields[i]))==3
-                interpol    =   linear_interpolation((EW_vec, NS_vec), V.fields[i][:,:,1], extrapolation_bc = NaN);            # create interpolation object
+                interpol    =   linear_interpolation((EW_vec, NS_vec), V.fields[i][:,:,1], extrapolation_bc = Flat());            # create interpolation object
             else
-                interpol    =   linear_interpolation((EW_vec, NS_vec), V.fields[i], extrapolation_bc = NaN);            # create interpolation object
+                interpol    =   linear_interpolation((EW_vec, NS_vec), V.fields[i], extrapolation_bc = Flat());            # create interpolation object
             end
 
             data_new    =   interpol.(EW, NS);                                                 # interpolate data field
@@ -937,9 +937,9 @@ function InterpolateDataFields2D(V::UTMData, EW, NS)
 
     # Interpolate z-coordinate as well
     if length(size(V.depth))==3
-        interpol    =   linear_interpolation((EW_vec, NS_vec), V.depth.val[:,:,1], extrapolation_bc = NaN);            # create interpolation object
+        interpol    =   linear_interpolation((EW_vec, NS_vec), V.depth.val[:,:,1], extrapolation_bc = Flat());            # create interpolation object
     else
-        interpol    =   linear_interpolation((EW_vec, NS_vec), V.depth.val, extrapolation_bc = NaN);            # create interpolation object
+        interpol    =   linear_interpolation((EW_vec, NS_vec), V.depth.val, extrapolation_bc = Flat());            # create interpolation object
     end
     depth_new =  interpol.(EW, NS);    
     

--- a/test/test_transformation.jl
+++ b/test/test_transformation.jl
@@ -13,21 +13,21 @@ Data_set3D_Cart =   Convert2CartData(Data_set3D, proj)
 @test sum(abs.(Value(Data_set3D_Cart.x))) ≈ 5.293469089428514e6km
 
 # Create Cartesian grid
-X,Y,Z           =   XYZGrid(-500:100:500,-900:200:900,(-500:100:0)km);
+X,Y,Z           =   XYZGrid(-400:100:400,-500:200:500,(-1300:100:0)km);
 Data_Cart       =   CartData(X,Y,Z,(Z=Z,))  
 
 # Project values of Data_set3D to the cartesian data
 Data_Cart       =   ProjectCartData(Data_Cart, Data_set3D, proj)
-@test sum(Data_Cart.fields.Depthdata) ≈ -316834.28716859705km
+@test sum(Data_Cart.fields.Depthdata) ≈ -967680.9136292854km
 #@test sum(Data_Cart.fields.Depthdata) ≈ -1.416834287168597e6km
-@test sum(Data_Cart.fields.LonData) ≈ 13165.712831402916
+@test sum(Data_Cart.fields.LonData) ≈ 15119.086370714615
 
 
 # Next, 3D surface (like topography)
 Lon,Lat,Depth   =   LonLatDepthGrid(5:25,20:50,0);
-Depth           =   cos.(Lon/5).*sin.(Lat)*10
-Data_surf       =   GeoData(Lon,Lat,Depth,(Z=Depth,))  
-Data_surf_Cart  =   Convert2CartData(Data_surf, proj)  
+Depth           =   cos.(Lon/5).*sin.(Lat)*10;
+Data_surf       =   GeoData(Lon,Lat,Depth,(Z=Depth,));  
+Data_surf_Cart  =   Convert2CartData(Data_surf, proj); 
 
 # Cartesian surface
 X,Y,Z           =   XYZGrid(-500:10:500,-900:20:900,0);


### PR DESCRIPTION
There are two changes:
1. When interpolating data fields of volume data (e.g. tomographies), data was extrapolated to points outside the domain. I changed that to assign NaNs to points outside the domain (otherwise we artificially create data where there is none).
2. When creating cross sections through volume data with given start and end points, I added the possibility to also provide a depth extent (via the tuple Depth_extent) of the profile. This allows to create profiles with the same resolution and lon/lat/depth ranges as others, which is required for comparisons between profiles.