### PR TITLE
Extend cross-section routines

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeophysicalModelGenerator"
 uuid = "3700c31b-fa53-48a6-808a-ef22d5a84742"
 authors = ["Boris Kaus", "Marcel Thielmann"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -81,13 +81,14 @@ test_cross      =   CrossSection(Data_setCart3D, Lon_level=15, dims=(50,100), In
 # Create 3D volume with some fake data
 Grid            = CreateCartGrid(size=(100,100,100), x=(0.0km, 99.9km), y=(-10.0km, 20.0km), z=(-40km,4km));
 X,Y,Z           = XYZGrid(Grid.coord1D...);
-DataSet         = CartData(X,Y,Z,(Depthdata=Z,))
+DataSet_Cart    = CartData(X,Y,Z,(Depthdata=Z,))
 
-test_cross      = CrossSection(DataSet, dims=(100,100), Interpolate=true, Start=(ustrip(Grid.min[1]),ustrip(Grid.max[2])), End=(ustrip(Grid.max[1]), ustrip(Grid.min[2])))
+test_cross_cart  = CrossSection(DataSet_Cart, dims=(100,100), Interpolate=true, Start=(ustrip(Grid.min[1]),ustrip(Grid.max[2])), End=(ustrip(Grid.max[1]), ustrip(Grid.min[2])))
 
-flatten_cross   = FlattenCrossSection(test_cross)
+flatten_cross   = FlattenCrossSection(test_cross_cart)
 
 @test flatten_cross[2][30]==1.0536089537226578
+@test test_cross_cart.fields.FlatCrossSection[2][30] == flatten_cross[2][30] # should be added by default
 
 # Flatten 3D CrossSection with GeoData
 Lon,Lat,Depth   =   LonLatDepthGrid(10:20,30:40,(-300:25:0)km);
@@ -106,16 +107,32 @@ Data_sub_Interp = ExtractSubvolume(Data_set3D,Lon_level=(10,15), Lat_level=(30,3
 @test Data_sub_Interp.fields[1][11]==-600km
 @test size(Data_sub_Interp.lat)==(51,21,32)
 
+Data_sub_Interp_Cart = ExtractSubvolume(DataSet_Cart,X_level=(10,15), Y_level=(10,12), Interpolate=true, dims=(51,21,32))
+@test Data_sub_Interp_Cart.fields[1][11]==-40km
+@test size(Data_sub_Interp_Cart.x)==(51,21,32)
+
+Data_cross_Interp_Cart = ExtractSubvolume(test_cross_cart,X_level=(10,50), Z_level=(-20,-5), dims=(51,61))
+@test Data_cross_Interp_Cart.fields[1][11]==18.0
+@test size(Data_cross_Interp_Cart.x)==(51,61,1)
+
 # no interpolation
 Data_sub_NoInterp = ExtractSubvolume(Data_set3D,Lon_level=(10,15), Lat_level=(30,32), Interpolate=false, dims=(51,21,32))
 @test Data_sub_NoInterp.fields[1][11]==-600km
 @test size(Data_sub_NoInterp.lat)==(6,3,13)
+
+Data_sub_Interp_Cart = ExtractSubvolume(DataSet_Cart,X_level=(10,15), Y_level=(10,12), Interpolate=false, dims=(51,21,32))
+@test Data_sub_Interp_Cart.fields[1][5]==-40km
+@test size(Data_sub_Interp_Cart.x)==(6,8,100)
+
 
 # Extract subset of cross-section
 test_cross      =   CrossSection(Data_set3D, Lat_level=35, dims=(50,100), Interpolate=true)
 Data_sub_cross  =   ExtractSubvolume(test_cross, Depth_level=(-100km,0km), Interpolate=false)
 @test Data_sub_cross.fields[1][11]==-200.00000000000003km
 @test size(Data_sub_cross.lat)==(50,1,34)
+
+test_cross_cart   =  CrossSection(DataSet_Cart, Start=(0.0,-9.0), End=(90.0, 19.0)) # Cartesian cross-section
+
 
 # compute the mean velocity per depth in a 3D dataset and subtract the mean from the given velocities
 Data_pert   =   SubtractHorizontalMean(ustrip(Data))    # 3D, no units


### PR DESCRIPTION
This enhances the way we can manipulate vertical cross-sections through 3D datasets. It allows you to project data onto a higher resolution area along a 2D cross-section taken through a 3D dataset.

Let's start with a vertical cross-section:
```Julia
julia> X,Y,Z = XYZGrid(10:20,30:40,-300:25:0);
julia> Data = Z.*2
julia> Data_Int = Int64.(Data)
julia> DataSet_Cart = CartData(X,Y,Z,(Data=Data,Data_Int=Data_Int, Velocity=(X,Y,Z)))
julia> Data_cross = CrossSection(DataSet_Cart, Start=(11.0,35), End=(19, 39.0))
CartData 
    size    : (100, 100, 1)
    x       ϵ [ 11.0 : 19.0]
    y       ϵ [ 35.0 : 39.0]
    z       ϵ [ -300.0 : 0.0]
    fields  : (:Data, :Data_Int, :Velocity, :FlatCrossSection)
  attributes: ["note"]
```

Note that this cross-section contains the field `FlatCrossSection`, which contains the "length along the cross-section".
If we now want to extract part of this cross-section and interpolate this onto a higher-resolution grid with `Nx=201, Nz=301`, we can do that with:
```Julia
julia> Data_extracted = ExtractSubvolume(Data_cross, X_level=(1,7), Z_level=(-200,-100), dims=(201,301))
CartData 
    size    : (201, 301, 1)
    x       ϵ [ 11.894427190999917 : 17.260990336999413]
    y       ϵ [ 35.44721359549995 : 38.130495168499706]
    z       ϵ [ -200.0 : -100.0]
    fields  : (:FlatCrossSection, :Depthdata)
  attributes: ["note"]
```