### PR TITLE
Update data_types.jl

### DIFF
--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -169,14 +169,14 @@ struct GeoData <: AbstractGeneralGrid
             lon = Vector(lon);
         end
         
-        # Check ordering of the arrays in case of 3D
+        # Check ordering of the arrays in case of 3D -- the check is not bullet proof for now
         if sum(size(lon).>1)==3
-            if maximum(abs.(diff(lon,dims=2)))>maximum(abs.(diff(lon,dims=1))) || maximum(abs.(diff(lon,dims=3)))>maximum(abs.(diff(lon,dims=1)))
-                error("It appears that the lon array has a wrong ordering")
-            end
-            if maximum(abs.(diff(lat,dims=1)))>maximum(abs.(diff(lat,dims=2))) || maximum(abs.(diff(lat,dims=3)))>maximum(abs.(diff(lat,dims=2)))
-                error("It appears that the lat array has a wrong ordering")
-            end
+           if maximum(abs.(diff(lon,dims=2)))>maximum(abs.(diff(lon,dims=1))) || maximum(abs.(diff(lon,dims=3)))>maximum(abs.(diff(lon,dims=1)))
+            @warn ("It appears that the lon array has a wrong ordering")
+           end
+           if maximum(abs.(diff(lat,dims=1)))>maximum(abs.(diff(lat,dims=2))) || maximum(abs.(diff(lat,dims=3)))>maximum(abs.(diff(lat,dims=2)))
+            @warn ("It appears that the lat array has a wrong ordering")
+           end
         end
 
         # fields should be a NamedTuple. In case we simply provide an array, lets transfer it accordingly


### PR DESCRIPTION
It seems that even when the ordering of the lon/lat array is correct, there is an error message and that the check for the ordering is not fully correct (a visual inspection of my dataset in Paraview looked ok). Until this is fully explored/fixed, I'd suggest to change the error into a warning so that the user is aware that the ordering may not be correct. 