### PR TITLE
Update and rename _typos.toml to .typos.toml

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,6 @@
 [default.extend-words]
 MOR = "MOR"
 dum = "dum"
+
+[files]
+extend-exclude = ["tutorials/*.pvsm"]


### PR DESCRIPTION
This adds `*.pvsm` files to the ignore list to avoid problems like in https://github.com/JuliaGeodynamics/GeophysicalModelGenerator.jl/actions/runs/8099469655/job/22135274742