### PR TITLE
Slab-internal temperature and linear thermal averaging

### DIFF
--- a/docs/src/man/geodynamic_setups.md
+++ b/docs/src/man/geodynamic_setups.md
@@ -21,4 +21,5 @@ GeophysicalModelGenerator.ConstantPhase
 GeophysicalModelGenerator.Compute_Phase
 GeophysicalModelGenerator.LithosphericPhases
 GeophysicalModelGenerator.McKenzie_subducting_slab
+GeophysicalModelGenerator.LinearWeightedTemperature
 ```

--- a/src/Setup_geometry.jl
+++ b/src/Setup_geometry.jl
@@ -1070,7 +1070,7 @@ function Compute_ThermalStructure(Temp, X, Y, Z,Phase, s::McKenzie_subducting_sl
 
     # Thickness of the layer: 
     D0          =   (maximum(Z)-minimum(Z));
-    Zshift      =   Z .- Z[1]       # McKenzie model is defined with Z = 0 at the bottom of the slab
+    Zshift      =   Z .- Z[end]       # McKenzie model is defined with Z = 0 at the bottom of the slab
 
     # Convert subduction velocity from cm/yr -> m/s; 
     convert_velocity = 1/(100.0*365.25*60.0*60.0*24.0);

--- a/src/Setup_geometry.jl
+++ b/src/Setup_geometry.jl
@@ -1065,11 +1065,11 @@ end
 
 Compute the temperature field of a `McKenzie_subducting_slab` scenario 
 """
-function Compute_ThermalStructure(Temp, X, Y, Z, s::McKenzie_subducting_slab)
+function Compute_ThermalStructure(Temp, X, Y, Z,Phase, s::McKenzie_subducting_slab)
     @unpack Tsurface, Tmantle, Adiabat, Age, v_cm_yr, κ, it = s
 
     # Thickness of the layer: 
-    D0          =   Z[end]-Z[1];
+    D0          =   maximum(Z)-minumum(Z);
 
     # Convert subduction velocity from cm/yr -> m/s; 
     convert_velocity = 1/(100.0*365.25*60.0*60.0*24.0);
@@ -1094,6 +1094,7 @@ function Compute_ThermalStructure(Temp, X, Y, Z, s::McKenzie_subducting_slab)
     end
 
     Temp           .= (Tmantle)* .+2 .*(Tmantle-Tsurface).*σ;
+    Temp           .= Temp + (Adiabat*abs.(Z))
     
     return Temp
 end

--- a/src/Setup_geometry.jl
+++ b/src/Setup_geometry.jl
@@ -1067,9 +1067,10 @@ Compute the temperature field of a `McKenzie_subducting_slab` scenario
 """
 function Compute_ThermalStructure(Temp, X, Y, Z,Phase, s::McKenzie_subducting_slab)
     @unpack Tsurface, Tmantle, Adiabat, v_cm_yr, κ, it = s
+    @show Tsurface, Tmantle, Adiabat, v_cm_yr, κ, it 
 
     # Thickness of the layer: 
-    D0          =   maximum(Z)-minimum(Z);
+    D0          =   (maximum(Z)-minimum(Z));
 
     # Convert subduction velocity from cm/yr -> m/s; 
     convert_velocity = 1/(100.0*365.25*60.0*60.0*24.0);
@@ -1078,6 +1079,7 @@ function Compute_ThermalStructure(Temp, X, Y, Z,Phase, s::McKenzie_subducting_sl
     
     # calculate the Reynolds number
     Re = (v_s*D0*1000)/2/κ;
+    @show Re, κ, v_s, v_cm_yr, D0
 
     # McKenzie model
     sc = 1/D0
@@ -1090,11 +1092,12 @@ function Compute_ThermalStructure(Temp, X, Y, Z,Phase, s::McKenzie_subducting_sl
         b   = (Re .- (Re.^2 .+ i .^2. *pi .^2) .^(0.5)) .*X .*sc;
         c   = sin.(i .*pi .*(1 .- abs.(Z .*sc))) ;
         e   = exp.(b);
-        σ .+= a.*e.*c
+        σ .+= a.*e.*c 
     end
+    @show extrema(σ)
 
-    Temp           .= (Tmantle)* .+2 .*(Tmantle-Tsurface).*σ;
-    Temp           .= Temp + (Adiabat*abs.(Z))
+    Temp           .= Tmantle .+ 2*(Tmantle-Tsurface).*σ;
+   # Temp           .= Temp + (Adiabat*abs.(Z))
     
     return Temp
 end

--- a/src/Setup_geometry.jl
+++ b/src/Setup_geometry.jl
@@ -102,10 +102,10 @@ function AddBox!(Phase, Temp, Grid::AbstractGeneralGrid;                 # requi
 
 
     # Set phase number & thermal structure in the full domain
-    ztop = zlim[2] - Origin[3]
-    zbot = zlim[1] - Origin[3]
-    ind = findall(  (Xrot .>= (xlim[1] - Origin[1])) .& (Xrot .<= (xlim[2] - Origin[1])) .&
-                    (Yrot .>= (ylim[1] - Origin[2])) .& (Yrot .<= (ylim[2] - Origin[2])) .&
+    ztop = maximum(zlim) - Origin[3]
+    zbot = minimum(zlim) - Origin[3]
+    ind = findall(  (Xrot .>= (minimum(xlim) - Origin[1])) .& (Xrot .<= (maximum(xlim) - Origin[1])) .&
+                    (Yrot .>= (minimum(ylim) - Origin[2])) .& (Yrot .<= (maximum(ylim) - Origin[2])) .&
                     (Zrot .>= zbot) .& (Zrot .<= ztop)  )
 
     # Compute thermal structure accordingly. See routines below for different options
@@ -1065,11 +1065,11 @@ end
 
 Compute the temperature field of a `McKenzie_subducting_slab` scenario 
 """
-function Compute_ThermalStructure(Temp, X, Y, Z,Phase, s::McKenzie_subducting_slab)
-    @unpack Tsurface, Tmantle, Adiabat, Age, v_cm_yr, κ, it = s
+function Compute_ThermalStructure(Temp, X, Y, Z, Phase, s::McKenzie_subducting_slab)
+    @unpack Tsurface, Tmantle, Adiabat, v_cm_yr, κ, it = s
 
     # Thickness of the layer: 
-    D0          =   maximum(Z)-minumum(Z);
+    D0          =   maximum(Z)-minimum(Z);
 
     # Convert subduction velocity from cm/yr -> m/s; 
     convert_velocity = 1/(100.0*365.25*60.0*60.0*24.0);

--- a/src/Setup_geometry.jl
+++ b/src/Setup_geometry.jl
@@ -13,7 +13,8 @@ export  AddBox!, AddSphere!, AddEllipsoid!, AddCylinder!, AddLayer!,
         makeVolcTopo,
         ConstantTemp, LinearTemp, HalfspaceCoolingTemp, SpreadingRateTemp, LithosphericTemp,
         ConstantPhase, LithosphericPhases,
-        Compute_ThermalStructure, Compute_Phase
+        Compute_ThermalStructure, Compute_Phase,
+        McKenzie_subducting_slab, LinearWeightedTemperature
 
 
 """
@@ -1032,3 +1033,127 @@ end
 
 # allow AbstractGeneralGrid instead of Z and Ztop
 Compute_Phase(Phase, Temp, Grid::LaMEM_grid, s::LithosphericPhases) = Compute_Phase(Phase, Temp, Grid.X, Grid.Y, Grid.Z, s::LithosphericPhases, Ztop=maximum(Grid.coord_z))
+
+
+
+"""
+    McKenzie_subducting_slab
+
+Thermal structure by McKenzie for a subducted slab that is fully embedded in the mantle.
+
+Parameters
+===
+- Tsurface:     Top T [C]
+- Tmantle:      Bottom T [C]
+- Adiabat:      Adiabatic gradient in K/km
+- v_cm_yr:      Subduction velocity [cm/yr]
+- κ:            Thermal diffusivity [m2/s]
+- it:           Number iterations employed in the harmonic summation
+
+"""
+@with_kw_noshow mutable struct McKenzie_subducting_slab <: AbstractThermalStructure
+    Tsurface::Float64 = 20.0       # top T
+    Tmantle::Float64  = 1350.0     # bottom T
+    Adiabat::Float64  = 0.4        # Adiabatic gradient in K/km
+    v_cm_yr::Float64  = 2.0        # velocity of subduction [cm/yr]
+    κ::Float64        = 1e-6       # Thermal diffusivity [m2/s]
+    it::Int64         = 36         # number of harmonic summation (look Mckenzie formula)
+end
+
+""" 
+    Compute_ThermalStructure(Temp, X, Y, Z, s::McKenzie_subducting_slab)
+
+Compute the temperature field of a `McKenzie_subducting_slab` scenario 
+"""
+function Compute_ThermalStructure(Temp, X, Y, Z, s::McKenzie_subducting_slab)
+    @unpack Tsurface, Tmantle, Adiabat, Age, v_cm_yr, κ, it = s
+
+    # Thickness of the layer: 
+    D0          =   Z[end]-Z[1];
+
+    # Convert subduction velocity from cm/yr -> m/s; 
+    convert_velocity = 1/(100.0*365.25*60.0*60.0*24.0);
+
+    v_s = v_cm_yr*convert_velocity;
+    
+    # calculate the Reynolds number
+    Re = (v_s*D0*1000)/2/κ;
+
+    # McKenzie model
+    sc = 1/D0
+
+    σ  = zeros(size(Temp));
+
+    # Dividi et impera
+    for i=1:it
+        a   = (-1).^(i)./(i.*pi)
+        b   = (Re .- (Re.^2 .+ i .^2. *pi .^2) .^(0.5)) .*X .*sc;
+        c   = sin.(i .*pi .*(1 .- abs.(Z .*sc))) ;
+        e   = exp.(b);
+        σ .+= a.*e.*c
+    end
+
+    Temp           .= (Tmantle)* .+2 .*(Tmantle-Tsurface).*σ;
+    
+    return Temp
+end
+
+"""
+    LinearWeightedTemperature
+
+Weight average structure -> correction from previous version Boris Kaus
+"""
+@with_kw_noshow mutable struct LinearWeightedTemperature <: AbstractThermalStructure 
+    w_min::Float64 = 0.0; 
+    w_max::Float64 = 1.0; 
+    crit_dist::Float64 = 100.0;
+    dir::Symbol =:X; 
+    F1::AbstractThermalStructure = ConstantTemp();
+    F2::AbstractThermalStructure = ConstantTemp();
+end
+
+"""
+    Weight average along distance
+    Do a weight average between two field along a specified direction 
+    Given a distance {could be any array, from X,Y} -> it increase from the origin the weight of 
+    F1, while F2 decreases. 
+    This function has been conceived for averaging the solution of Mckenzie and half space cooling model, but in 
+    can be used to smooth the temperature field from continent ocean: 
+    -> Select the boundary to apply; 
+    -> transform the coordinate such that dist represent the perpendicular direction along which you want to apply
+    this smoothening and in a such way that 0.0 is the point in which the weight of F1 is equal to 0.0; 
+    -> Select the points that belongs to this area -> compute the thermal fields {F1} {F2} -> then modify F. 
+"""
+function Compute_ThermalStructure(Temp, X, Y, Z, Phase, s::LinearWeightedTemperature)
+    @unpack w_min, w_max, crit_dist,dir = s; 
+    @unpack F1, F2 = s; 
+    
+    if dir === :X
+        dist = X; 
+    elseif dir ===:Y 
+        dist = Y; 
+    else
+        dist = Z; 
+    end
+  
+    # compute the 1D thermal structures
+    Temp1 =  Compute_ThermalStructure(Temp, X, Y, Z, Phase, F1);
+    
+    Temp2 =  Compute_ThermalStructure(Temp, X, Y, Z, Phase, F2);
+
+    # Compute the weights
+    weight = w_min .+(w_max-w_min) ./(crit_dist) .*(dist)
+
+    ind_1 = findall(weight .>w_max);
+    
+    ind_2 =findall(weight .<w_min);
+
+    # Change the weight 
+    weight[ind_1] .= w_max; 
+    
+    weight[ind_2] .= w_min;
+
+    # Average
+    Temp = Temp1 .*weight+ Temp2 .*(1.0 - weight); 
+    return Temp
+end

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -188,15 +188,14 @@ TsMK = McKenzie_subducting_slab(Tsurface = 20.0, Tmantle = 1350.0, v_cm_yr = 4.0
 # horizontal 
 Temp    = ones(Float64,size(Cart))*1350;
 AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0, 0.0), phase = ConstantPhase(5), T=TsMK);
-@test sum(Temp)  ≈ 3.518284446708499e8
+@test sum(Temp)  ≈ 3.518172093383281e8
 
 # inclined
 Temp    = ones(Float64,size(Cart))*1350;
 AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0,0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=TsMK);
-@test sum(Temp)  ≈ 3.51230950244323e8
+@test sum(Temp)  ≈ 3.5133669349123573e8
 
 
- 
 #  T_slab = LinearWeightedTemperature(0.1,1.0,100.0,:X,TsMK,TsHC);
 
 #  AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(0.0,-80.0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=McKenzie(20.0));

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -178,15 +178,24 @@ Temp    = ones(Float64,size(Cart))*1350;
 
 # Create thermal structures
 TsHC = HalfspaceCoolingTemp(Tsurface=20.0, Tmantle=1350, Age=120, Adiabat=0.4)
-TsMK = McKenzie_subducting_slab(Tsurface = 20.0, Tmantle = 1350.0, v_cm_yr = 4.0, Adiabat = 0.4)
+TsMK = McKenzie_subducting_slab(Tsurface = 20.0, Tmantle = 1350.0, v_cm_yr = 4.0, Adiabat = 0.0)
 
 @test TsMK.v_cm_yr == 4.0
 @test TsMK.it == 36
 
 # Add a box with a McKenzie thermal structure
-AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0,0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=TsMK);
 
- 
+# horizontal 
+Temp    = ones(Float64,size(Cart))*1350;
+AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0, 0.0), phase = ConstantPhase(5), T=TsMK);
+@test sum(Temp)  ≈ 3.518284446708499e8
+
+# inclined
+Temp    = ones(Float64,size(Cart))*1350;
+AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0,0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=TsMK);
+@test sum(Temp)  ≈ 3.51230950244323e8
+
+
  
 #  T_slab = LinearWeightedTemperature(0.1,1.0,100.0,:X,TsMK,TsHC);
 

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -193,7 +193,7 @@ AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0, 0.0),
 # inclined slab
 Temp    = ones(Float64,size(Cart))*1350;
 AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0,0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=TsMK);
-@test sum(Temp)  ≈ 3.5133669349123573e8
+@test sum(Temp)  ≈ 3.5125017626287365e8
 
 
 

--- a/test/test_setup_geometry.jl
+++ b/test/test_setup_geometry.jl
@@ -190,14 +190,24 @@ Temp    = ones(Float64,size(Cart))*1350;
 AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0, 0.0), phase = ConstantPhase(5), T=TsMK);
 @test sum(Temp)  ≈ 3.518172093383281e8
 
-# inclined
+# inclined slab
 Temp    = ones(Float64,size(Cart))*1350;
 AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0,0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=TsMK);
 @test sum(Temp)  ≈ 3.5133669349123573e8
 
 
-#  T_slab = LinearWeightedTemperature(0.1,1.0,100.0,:X,TsMK,TsHC);
 
-#  AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(0.0,-80.0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=McKenzie(20.0));
+# horizontal slab, constant T
+T_slab  = LinearWeightedTemperature(0,1,600.0,:X,ConstantTemp(1000), ConstantTemp(2000));
+Temp    = ones(Float64,size(Cart))*1350;
+AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0, 0.0), phase = ConstantPhase(5), T=T_slab);
+@test sum(Temp)  ≈ 3.549127111111111e8
 
-#  Data_Final      =   CartData(X,Y,Z,(Phase=Phase,Temp=Temp)) 
+# horizontal slab, halfspace and McKenzie
+T_slab = LinearWeightedTemperature(crit_dist=600, F1=TsHC, F2=TsMK);
+Temp    = ones(Float64,size(Cart))*1350;
+AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0, 0.0), phase = ConstantPhase(5), T=T_slab);
+@test sum(Temp)  ≈ 3.499457641038468e8
+
+
+Data_Final =   AddField(Cart,"Temp",Temp)


### PR DESCRIPTION
This PR adds two features:

_1) Slab-internal thermal structure of a slab within the mantle_
This follows McKenzie (1969) in computing a thermal structure within a slab:
```Julia
# Create CartGrid struct
x       = LinRange(0.0,1200.0,64);
y       = LinRange(0.0,1200.0,64);
z       = LinRange(-660,50,64);
Cart    = CartData(XYZGrid(x, y, z));
Phase   = ones(Int32,size(Cart));
Temp    = ones(Float64,size(Cart))*1350;

# Create thermal structures
TsMK = McKenzie_subducting_slab(Tsurface = 20.0, Tmantle = 1350.0, v_cm_yr = 4.0, Adiabat = 0.0)

# horizontal 
Temp    = ones(Float64,size(Cart))*1350;
AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0,0),StrikeAngle=0, DipAngle=45, phase = ConstantPhase(5), T=TsMK);
```
<img width="1161" alt="Screenshot 2024-03-08 at 20 48 03" src="https://github.com/JuliaGeodynamics/GeophysicalModelGenerator.jl/assets/61824822/9baf9645-441e-40b0-ac9c-0ad7a0adba8c">

_2) Averaging temperature along a slab between two end member profiles_
This allows a linear transition between two endmember 1D profiles:
```Julia
TsHC = HalfspaceCoolingTemp(Tsurface=20.0, Tmantle=1350, Age=120, Adiabat=0.4)
TsMK = McKenzie_subducting_slab(Tsurface = 20.0, Tmantle = 1350.0, v_cm_yr = 4.0, Adiabat = 0.0)
T_slab = LinearWeightedTemperature(crit_dist=600, F1=TsHC, F2=TsMK);
Temp    = ones(Float64,size(Cart))*1350;
AddBox!(Phase, Temp, Cart; xlim=(0.0,600.0),ylim=(0.0,600.0), zlim=(-80.0, 0.0), phase = ConstantPhase(5), T=T_slab);
```
<img width="938" alt="Screenshot 2024-03-08 at 20 50 31" src="https://github.com/JuliaGeodynamics/GeophysicalModelGenerator.jl/assets/61824822/3ba00096-d533-4fe9-84e2-02a6ef8d2faf">
