### PR TITLE
Multiple download attempts for remote data

### DIFF
--- a/src/IO.jl
+++ b/src/IO.jl
@@ -71,7 +71,9 @@ function load_GMG(filename::String, dir=pwd(); maxattempts=5)
     data =  load_object(file_ext)
 
     # remove local temporary file
-    rm(local_filename)
+    if contains(filename,"http")
+        rm(local_filename)
+    end
 
     return data
 end 

--- a/src/IO.jl
+++ b/src/IO.jl
@@ -23,10 +23,11 @@ function save_GMG(filename::String, data::Union{GeoData, CartData, UTMData}; dir
 end 
 
 """
-    load_GMG(filename::String, dir=pwd())
+    load_GMG(filename::String, dir=pwd(); maxattempts=5)
 
 Loads a `GeoData`/`CartData`/`UTMData` data set from jld2 file `filename`
-Note: the `filename` can also be a remote `url`, in which case we first download that file to a temporary directory before opening it
+Note: the `filename` can also be a remote `url`, in which case we first download that file to a temporary directory before opening it.
+We make `maxattempts` attempts to download it before giving up.
 
 Example 1 - Load local file
 ====
@@ -56,11 +57,11 @@ GeoData
 ```
 
 """
-function load_GMG(filename::String, dir=pwd())
+function load_GMG(filename::String, dir=pwd(); maxattempts=5)
 
+    local_filename = "download_GMG_temp.jld2"
     if contains(filename,"http")
-        #download remote file to a local temporary directory
-        file_ext = Downloads.download(filename, joinpath(pwd(),"download_GMG_temp.jld2"))
+        file_ext = download_data(filename, local_filename, dir=dir, maxattempts=maxattempts)
     else
         # local file
         file_ext = joinpath(dir,filename*".jld2")
@@ -69,6 +70,9 @@ function load_GMG(filename::String, dir=pwd())
     # load data:
     data =  load_object(file_ext)
 
+    # remove local temporary file
+    rm(local_filename)
+
     return data
 end 
 
@@ -76,9 +80,10 @@ end
 
 
 """
-    download_data(url::String, local_filename="temp.dat"; dir=pwd() )
+    download_data(url::String, local_filename="temp.dat"; dir=pwd(), maxattempts=5 )
 
-Downloads a remote dataset with name `url` from a remote location and saves it to the current directory
+Downloads a remote dataset with name `url` from a remote location and saves it to the current directory.
+If download fails, we make `maxattempts` attempts before giving up.
 
 Example
 ====
@@ -89,14 +94,28 @@ julia> download_data(url)
 ```
 
 """
-function download_data(url::String, local_filename="temp.dat"; dir=pwd() )
+function download_data(url::String, local_filename="temp.dat"; dir=pwd(), maxattempts=5)
 
     if !contains(url,"http")
         @warn "the url does not contain http; please double check that it worked"
     end
 
-    # download remote file to a local temporary directory
-    file_ext = Downloads.download(url, joinpath(dir,local_filename))
+    #download remote file to a local temporary directory
+    file_ext = [];
+    attempt = 0
+    while attempt<maxattempts
+      try
+        file_ext = Downloads.download(url, joinpath(dir,local_filename))
+        break
+      catch
+        @warn "Failed downloading data on attempt $attempt/$maxattempts"
+        sleep(5)  # wait a few sec
+      end
+      attempt += 1
+    end
+    if isempty(file_ext)
+      error("Could not download GMT topography data")
+    end
 
     return file_ext
 end 


### PR DESCRIPTION
The CI frequently fails because of problems with downloading remote data. This PR makes several download attempts before giving up, with the hope to reduce this issue. We also delete the local download file from disk once data is downloaded and imported using `load_GMG` with a remote dataset