### PR TITLE
Make `ProjectionPoint` type stable

### DIFF
--- a/src/data_types.jl
+++ b/src/data_types.jl
@@ -26,7 +26,7 @@ struct ProjectionPoint
     Lon     :: Float64
     EW      :: Float64
     NS      :: Float64
-    zone    :: Integer
+    zone    :: Int64
     isnorth :: Bool
 end
 


### PR DESCRIPTION
Quick fix to make `ProjectionPoint`  type stable. `Int` is an abstract type, while `Int64` is concrete.