### PR TITLE
New function for generating tectonic plates with custom geometries and constant depth

### DIFF
--- a/src/Setup_geometry.jl
+++ b/src/Setup_geometry.jl
@@ -299,7 +299,7 @@ function add_box!(Phase, Temp, Grid::AbstractGeneralGrid;       # required input
                 Phase[ind_flat] = compute_phase(Phase[ind_flat], Temp[ind_flat], Xrot[ind], Yrot[ind], Zrot[ind], phase)
             end
             if segments !== nothing
-                Temp[ind_flat] = compute_thermal_structure(Temp[ind_flat], X[ind], Y[ind], Z[ind], Phase[ind_flat], T, segments)
+                Temp[ind_flat] = compute_thermal_structure(Temp[ind_flat], Xrot[ind], Yrot[ind], Zrot[ind], Phase[ind_flat], T, segments)
             else
                 Temp[ind_flat] = compute_thermal_structure(Temp[ind_flat], Xrot[ind], Yrot[ind], Zrot[ind], Phase[ind_flat], T)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,10 @@ using Test
     	include("test_ridge_segments.jl")
     end
 
+    @testset "Plate Tests" begin
+        include("test_plate.jl")
+    end
+
     @testset "Waterflow" begin
         include("test_WaterFlow.jl")
     end

--- a/test/test_plate.jl
+++ b/test/test_plate.jl
@@ -1,0 +1,47 @@
+using GeophysicalModelGenerator
+using Test
+
+@testset "Plate Tests" begin
+    # Grid parameters
+    nx, ny, nz = 512, 512, 128
+    x = range(-1000, 0, length=nx)
+    y = range(-1000, 1000, length=ny)
+    z = range(-660, 0, length=nz)
+    Grid = CartData(xyz_grid(x, y, z))
+
+    # Phases and temperature
+    Phases = fill(2, nx, ny, nz)
+    Temp = fill(1350.0, nx, ny, nz)
+
+    # Ridge Segments
+    segments = [
+        ((-500.0, -1000.0), (-500.0, 0.0)),  # Segment 1
+        ((-250.0, 0.0), (-250.0, 200.0)),    # Segment 2
+        ((-750.0, 200.0), (-750.0, 1000.0))  # Segment 3
+    ]
+
+    # Lithospheric phases
+    lith = LithosphericPhases(Layers=[15 55], Phases=[1 2], Tlab=1250)
+
+    # Replace add_box with add_polygon_xy to allow for arbitrary-shaped ridges
+    add_plate!(Phases, Temp, Grid; 
+        xlim=(-1000.0, -750.0, -250.0, 0.0, -250.0, -750.0), 
+        ylim=(0.0, 500.0, 500.0, 0.0, -500.0, -500.0), 
+        zlim=(-150.0, 0.0), 
+        phase=lith, 
+        T=SpreadingRateTemp(SpreadingVel=3), 
+        segments=segments)
+
+    # Add and save results
+    Grid = addfield(Grid, (; Phases, Temp))
+    write_paraview(Grid, "Plate")
+
+    @test minimum(Temp) >= 0.0  # Minimum temperature
+    @test maximum(Temp) <= 1350.0  # Maximum temperature
+    @test all(≥(0),    Temp) # Ensure no negative temperatures
+    @test all(≤(1350), Temp) # Ensure no temperatures above max
+
+    # Check if phases are correctly assigned in expected regions
+    @test first(Phases) == 2  # Example: Verify a point's phase
+    @test last(Phases)  == 2  # Example: Verify another point's phase.
+end


### PR DESCRIPTION
This pull request introduces a new function, add_plate, to create tectonic plates based on xy coordinates. This function builds upon the existing functionality of add_polygon, but is specifically adapted for defining tectonic plates with complex geometries and properties. The user can input multiple coordinates in the x and y directions to define the plate's geometry, while specifying a single tuple in the z direction to determine the depth range of the plate.

Additionally, this new function integrates the recently introduced functionality for segmented ridges, allowing plates to incorporate ridge structures. The add_plate function now accepts the temperature calculations from the ridge structure, enabling more accurate thermal and phase modeling for tectonic plates.

![Screenshot from 2025-01-19 09-13-26](https://github.com/user-attachments/assets/9739fc29-53a1-4807-8c6e-41246e5df800)

![Screenshot from 2025-01-19 09-13-48](https://github.com/user-attachments/assets/009b4beb-a7c0-4023-b994-11bf39747641)

