### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeophysicalModelGenerator"
 uuid = "3700c31b-fa53-48a6-808a-ef22d5a84742"
 authors = ["Boris Kaus", "Marcel Thielmann"]
-version = "0.7.12"
+version = "0.7.13"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"


### PR DESCRIPTION
bumps version of GMG to account for GP 0.7.0 as we have experienced version conflicts while updating other pkgs without `add GMG#main`