### PR TITLE
Make `ParallelTestRunner` a test-only dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MeshIO = "7269a6da-0436-5bbc-96c2-40638cbb6118"
 NearestNeighbors = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -79,8 +78,9 @@ Chmy = "33a72cf0-4690-46d7-b987-06506c2248b9"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "GMT", "StableRNGs", "GridapGmsh", "Chmy", "KernelAbstractions", "NCDatasets"]
+test = ["Test", "GMT", "StableRNGs", "GridapGmsh", "Chmy", "KernelAbstractions", "NCDatasets", "ParallelTestRunner"]


### PR DESCRIPTION
### Whats the purpose of this PR?
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other, please explain

**Describe it in more detail below:**

ParallelTestRunner shouldn't be a direct dependency, it's only used for the tests.

**Checklist**
- [x] The PR title is descriptive and starts with the appropriate tag: `[BUGFIX]`, `[ADDITION]`, `[DOC]`, etc.
- [ ] New tests (either assessing the correct behaviour of new internal functions or the correctness of a tutorial) were added, or old tests were updated
- [ ] Affected tutorials have also been updated
- [ ] The new feature was added in a way that does not break public API
- [ ] New documentation related to the new feature was added
- [ ] The new code follows the [contributor guidelines](https://github.com/JuliaGeodynamics/GeophysicalModelGenerator.jl/blob/main/CONTRIBUTING.md), in particular the [Runic Style](https://github.com/fredrikekre/Runic.jl)